### PR TITLE
fixed filtering/merging selected state paths for saving + added tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,30 +18,11 @@ export default function(options?: Options) {
     statesPaths = options.statesPaths ? options.statesPaths : statesPaths;
   }
 
-  function filterStates(
-    paths: string[],
-    state: { [key: string]: any }
-  ): { [key: string]: any } {
-    let result = {};
-    paths.forEach(path => {
-      const subPaths = path.split('.');
-      let object: { [key: string]: any } = {};
-      const branch = object;
-
-      const value = subPaths.reduce((current, subPath) => {
-        return current[subPath];
-      }, state);
-
-      for (let i = 0; i < subPaths.length - 1; i += 1) {
-        object[subPaths[i]] = {};
-        object = object[subPaths[i]];
-      }
-
-      object[subPaths[subPaths.length - 1]] = value;
-
-      result = { ...result, ...branch };
+  function filterStates(state: { [key: string]: any }): { [key: string]: any } {
+    const result = {};
+    statesPaths.forEach(statePath => {
+      _set(result, statePath, _get(state, statePath));
     });
-
     return result;
   }
 
@@ -80,7 +61,7 @@ export default function(options?: Options) {
 
       // Filter state
       if (statesPaths.length > 0) {
-        toSave = filterStates(statesPaths, state);
+        toSave = filterStates(state);
       }
 
       // Save state in local storage

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -62,6 +62,32 @@ describe('vuex-multi-tab-state basic tests', () => {
     }
   });
 
+  it('should properly merge specified states when saving to local storage', () => {
+    const store = new Vuex.Store({
+      state: { bar: { random: 0, rainbow: 0 } },
+      mutations: {
+        incrementBarRandom(state) {
+          state.bar.random += 1;
+        },
+      },
+      plugins: [
+        createMultiTabState({ statesPaths: ['bar.random', 'bar.rainbow'] }),
+      ],
+    });
+
+    store.commit('incrementBarRandom');
+
+    const stateInLs: string | null = window.localStorage.getItem(
+      'vuex-multi-tab'
+    );
+
+    if (typeof stateInLs === 'string') {
+      const parsedStateInLs = JSON.parse(stateInLs);
+      expect(parsedStateInLs.state.bar.random).to.be.eq(1);
+      expect(parsedStateInLs.state.bar.rainbow).to.be.eq(0);
+    }
+  });
+
   it('should merge arrays correctly', () => {
     const store = new Vuex.Store({
       state: { random: ['bar', 'foo'] },

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -62,7 +62,7 @@ describe('vuex-multi-tab-state basic tests', () => {
     }
   });
 
-  it('should properly merge specified states when saving to local storage', () => {
+  it('should properly merge specified states from same parent when saving to local storage', () => {
     const store = new Vuex.Store({
       state: { bar: { random: 0, rainbow: 0 } },
       mutations: {
@@ -266,6 +266,24 @@ describe('vuex-multi-tab-state basic tests', () => {
     });
 
     expect(warnSpy).to.have.been.called;
+  });
+
+  it('should accept custom local storage key', () => {
+    const store = new Vuex.Store({
+      state: { bar: 'foo1' },
+    });
+    const plugin = createMultiTabState({ key: 'custom-key' });
+
+    window.localStorage.setItem(
+      'custom-key',
+      JSON.stringify({
+        id: 'randomIdHere',
+        state: { bar: 'foo2' },
+      })
+    );
+
+    plugin(store);
+    expect(store.state.bar).to.be.eql('foo2');
   });
 
   it('should throw if local storage is not available', () => {


### PR DESCRIPTION
Hey,
with #21 I replaced `result = merge(result, branch);` with `result = { ...result, ...branch };` as I thought that would result in the same thing and remove one dependency. Well, it didn't. It broke filtering states in cases, where in options provided were two state subpaths with same parent (like say, `['random.bar2', 'random.bar3']`). Lodash merge is recursive, so it kept `random.bar2` when merging `random.bar3`, but merging with spread syntax isn't - it replaced whole `random` with `random.bar3` removing `random.bar2`. Oops, sorry. ^^

This PR seeks to rectify that. Test case & fix included.

Also, simplified code for that a bit (using similar approach to merging new state with old state).
And added one new test case for improved coverage.

Shouldn't break anything new this time. ^^

Requesting review @gabrielmbmb.